### PR TITLE
Fix xattr emblems on files in pup_rw when using overlay

### DIFF
--- a/ROX-Filer/src/xtypes.c
+++ b/ROX-Filer/src/xtypes.c
@@ -107,6 +107,7 @@ int xattr_supported(const char *path)
 
 int xattr_have(const char *path)
 {
+	static char buf[128];
 	ssize_t nent;
 
 	RETURN_IF_IGNORED(FALSE);
@@ -115,7 +116,7 @@ int xattr_have(const char *path)
 		return FALSE;
 
 	errno=0;
-	nent=dyn_listxattr(path, NULL, 0);
+	nent=dyn_listxattr(path, buf, sizeof(buf));
 
 	if(nent<0 && errno==ERANGE)
 		return TRUE;


### PR DESCRIPTION
`listxattr("/archive", NULL, 0)` returns 23, not 0 as the code expects. 

This causes these emblems to appear:

![xattr](https://user-images.githubusercontent.com/1471149/211208416-54f327b0-1140-4bee-99c2-cdbc38d237db.png)
